### PR TITLE
Stable http message bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: php
 install:
   - composer install
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 after_success:
   - vendor/bin/test-reporter
+env:
+  - dependencies=lowest
+  - dependencies=""
 php:
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5",
         "psr/http-message": "^1.0",
-        "symfony/psr-http-message-bridge": "^0.2.0",
+        "symfony/psr-http-message-bridge": "^0.2.0|^1.0",
         "zendframework/zend-diactoros": "^1.3",
         "silex/silex": "~1"
     },


### PR DESCRIPTION
I've updated to allow the stable release of this dependency.

I've kept `^0.2.0` in because other libraries might have pinned the component to `^0.2.0` but not updated yet. This means people will still get a working configuration even if they have other libraries installed which depend on `0.2`. 

I've tried to get Travis to test with both so as not to use a new feature in e.g. `1.4` and break compatibility, but by then we can probably just drop the requirement. 

